### PR TITLE
REST docs 적용 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.springframework.boot' version '2.1.7.RELEASE'
+    id 'org.asciidoctor.convert' version '1.5.7'
     id 'java'
 }
 
@@ -25,6 +26,7 @@ repositories {
 }
 
 ext {
+    snippetsDir = file('build/generated-snippets')
     set('springCloudVersion', "Greenwich.BUILD-SNAPSHOT")
 }
 
@@ -46,7 +48,8 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java'
 
     annotationProcessor 'org.projectlombok:lombok'
-
+    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.3.RELEASE'
+    testImplementation "org.springframework.restdocs:spring-restdocs-webtestclient:2.0.3.RELEASE"
     testImplementation 'io.findify:s3mock_2.12:0.2.5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.mockito:mockito-junit-jupiter'
@@ -56,8 +59,22 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'junit'
     }
+}
 
+test {
+    outputs.dir snippetsDir
+}
 
+asciidoctor {
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from ("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
 }
 
 dependencyManagement {

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -1,0 +1,1079 @@
+= TurkeyBook REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:snippets: ../../../build/generated-snippets
+
+[[Introduction]]
+== 소개
+이 문서는 Turkeybook 서비스의 API 명세를 작성한 문서입니다.\
+
+[[Environment]]
+== 개발 환경
+[cols="2*^"]
+|===
+| 환경 | 버전
+
+| Java | 1.8 JDK
+| Spring Boot | 2.1.7.RELEASE
+| DB(MySQL) | 8.0.17
+| AWS EC2 | -
+| AWS S3 | -
+|===
+
+[[Common]]
+== 공통사항
+
+API에 공통으로 적용되는 사항입니다.
+
+=== Cookie
+
+TurkeyBook의 API 서버 인증은 쿠키 & 세션으로 관리하고 있습니다. 따라서 **회원가입**, **로그인**을 제외한 모든 API 요청은 아래 쿠키를 필요로 합니다.
+
+[cols="2*^"]
+|===
+| field | description
+| JSESSIONID | 서버의 세션에 접근하기 위한 key
+|===
+
+== User API
+
+=== CREATE
+
+유저 생성 API 관련 형식 및 예시
+
+Request 형식:
+
+include::{snippets}/user/201/create/request-fields.adoc[]
+
+Response Header 형식:
+
+include::{snippets}/user/201/create/response-headers.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/user/201/create/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/user/201/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/201/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/201/create/http-response.adoc[]
+
+=== Error
+
+User 생성과 관련된 오류 발생 조건은 다음과 같습니다.
+
+- password : 이메일 형식이 아닌 경우
+- name : 문자 2~10글자 형식이 아닌 경우
+- passowrd : 영대소문자, 숫자, 특수문자를 모두 포함한 8~20자
+- 이메일 중복
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/user/400/create/password/response-fields.adoc[]
+
+==== Email 오류
+
+이메일 형식이 아닌 경우
+
+CURL:
+
+include::{snippets}/user/400/create/email/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/400/create/email/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/400/create/email/http-response.adoc[]
+
+==== name 오류
+
+이름 형식에 맞지 않는 경우
+
+CURL:
+
+include::{snippets}/user/400/create/name/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/400/create/name/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/400/create/name/http-response.adoc[]
+
+==== password 오류
+
+password 형식에 맞지 않는 경우
+
+CURL:
+
+include::{snippets}/user/400/create/password/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/400/create/password/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/400/create/password/http-response.adoc[]
+
+==== email 중복
+
+이미 가입된 email이 있는 경우
+
+CURL:
+
+include::{snippets}/user/400/create/overlap/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/400/create/overlap/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/400/create/overlap/http-response.adoc[]
+
+=== READ
+
+유저 조회 API 관련 형식 및 예시
+
+Request Path Parameter:
+
+include::{snippets}/user/200/read/path-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/user/200/read/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/user/200/read/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/200/read/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/200/read/http-response.adoc[]
+
+=== Error
+
+User 조회와 관련된 오류 발생 조건은 다음과 같습니다.
+
+- 존재하지 않는 유저 id인 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/user/400/create/password/response-fields.adoc[]
+
+
+==== 존재하지 않는 유저
+
+CURL:
+
+include::{snippets}/user/400/read/none/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/400/read/none/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/400/read/none/http-response.adoc[]
+
+=== Update
+
+유저 수정 API는 지원하지 않습니다.
+
+=== Delete
+
+유저 삭제 API 관련 형식 및 예시
+
+Request Path Parameter:
+
+include::{snippets}/user/204/delete/path-parameters.adoc[]
+
+CURL:
+
+include::{snippets}/user/204/delete/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/204/delete/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/204/delete/http-response.adoc[]
+
+==== Error
+
+User 삭제와 관련된 오류 발생 조건은 다음과 같습니다.
+
+- 존재하지 않는 유저 id인 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/user/400/create/password/response-fields.adoc[]
+
+==== 존재하지 않는 유저
+
+CURL:
+
+include::{snippets}/user/400/delete/none/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/user/400/delete/none/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/user/400/delete/none/http-response.adoc[]
+
+== Login API
+
+로그인 API 관련 형식 및 예시
+
+Request 형식:
+
+include::{snippets}/login/request-fields.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/login/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/login/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/login/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/login/http-response.adoc[]
+
+== Logout API
+
+로그아웃 API 관련 형식 및 예시
+
+Response Body 형식:
+
+include::{snippets}/login/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/login/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/login/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/login/http-response.adoc[]
+
+== Introduction API
+
+=== CREATE
+
+유저의 소개를 작성하는 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/introduction/200/create/path-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/introduction/200/create/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/introduction/200/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/introduction/200/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/introduction/200/create/http-response.adoc[]
+
+==== Error
+
+소개 작성시 발생하는 오류는 다음과 같습니다.
+
+- 소개 내용이 없는 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+==== 소개 내용이 없는 경우
+
+Response Body 형식:
+
+include::{snippets}/introduction/400/create/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/introduction/400/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/introduction/400/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/introduction/400/create/http-response.adoc[]
+
+=== Update
+
+유저의 소개를 수정하는 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/introduction/200/update/path-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/introduction/200/update/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/introduction/200/update/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/introduction/200/update/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/introduction/200/update/http-response.adoc[]
+
+==== Error
+
+소개 수정시 발생하는 오류는 다음과 같습니다.
+
+- id가 null이거나 존재하지 않는 소개의 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/introduction/400/update/response-fields.adoc[]
+
+==== id가 null인 경우
+
+CURL:
+
+include::{snippets}/introduction/400/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/introduction/400/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/introduction/400/create/http-response.adoc[]
+
+== Friend Ask
+
+친구 요청 관련 API 형식 및 예시
+
+=== Create
+
+친구 요청을 만드는 API 관련 형식 및 예시
+
+Request 형식:
+
+include::{snippets}/friend/ask/201/create/request-fields.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/friend/ask/201/create/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/friend/ask/201/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/ask/201/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/201/create/http-response.adoc[]
+
+==== Error
+
+친구 요청 생성시 발생하는 오류는 다음과 같습니다.
+
+- 이미 친구인 경우
+- 이미 친구 요청을 한 경우
+- 이미 친구 요청을 받은 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/friend/ask/400/already-exist/response-fields.adoc[]
+
+==== 존재하지 않는 id인 경우
+
+CURL:
+
+include::{snippets}/friend/ask/400/create/none/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/ask/400/create/none/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/400/create/none/http-response.adoc[]
+
+==== 이미 친구인 경우
+
+CURL:
+
+include::{snippets}/friend/ask/400/create/already-friend/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/ask/400/create/already-friend/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/400/create/already-friend/http-response.adoc[]
+
+==== 이미 친구 요청을 한 경우
+
+CURL:
+
+include::{snippets}/friend/ask/400/already-exist/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/ask/400/already-exist/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/400/already-exist/http-response.adoc[]
+
+==== 이미 친구 요청을 받은 경우
+
+CURL:
+
+include::{snippets}/friend/ask/400/already-receive/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/ask/400/already-receive/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/400/already-receive/http-response.adoc[]
+
+=== Read
+
+친구 요청을 조회하는 API 관련 형식 및 예시
+
+Response Body 형식:
+
+include::{snippets}/friend/ask/200/read/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/friend/ask/200/read/curl-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/200/read/http-response.adoc[]
+
+=== Delete
+
+친구 요청을 삭제하는 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/friend/ask/204/delete/path-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/friend/ask/200/read/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/friend/ask/200/read/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/ask/200/read/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/200/read/http-response.adoc[]
+
+==== Error
+
+친구 요청 삭제시 발생하는 오류는 다음과 같습니다.
+
+- 존재하지 않는 친구 요청인 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/friend/ask/400/delete/response-fields.adoc[]
+
+==== 존재하지 않는 친구 요청
+
+CURL:
+
+include::{snippets}/friend/ask/400/delete/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/ask/400/delete/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/ask/400/delete/http-response.adoc[]
+
+== Friend
+
+친구 관련 API 형식 및 예시
+
+=== Create
+
+친구 생성 API 관련 형식 및 예시
+
+Request 형식:
+
+include::{snippets}/friend/201/create/request-fields.adoc[]
+
+CURL:
+
+include::{snippets}/friend/201/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/201/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/201/create/http-response.adoc[]
+
+=== Read
+
+친구 조회 API 관련 형식 및 예시
+
+Response Body 형식:
+
+include::{snippets}/friend/200/read/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/friend/200/read/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/200/read/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/200/read/http-response.adoc[]
+
+=== Delete
+
+친구 삭제 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/friend/204/delete/path-parameters.adoc[]
+
+CURL:
+
+include::{snippets}/friend/204/delete/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/friend/204/delete/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/friend/204/delete/http-response.adoc[]
+
+== Post
+
+게시물 관련 API 형식 및 예시
+
+=== Create
+
+게시물을 만드는 API 관련 형식 및 예시
+
+==== 사진, 동영상이 있는 경우
+
+Request Parts:
+
+include::{snippets}/post/201/create/withfiles/request-parts.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/post/201/create/withfiles/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/post/201/create/withfiles/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/201/create/withfiles/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/201/create/withfiles/http-response.adoc[]
+
+==== 사진, 동영상이 없는 경우
+
+사진, 동영상이 없는 경우는 위 예시에서 Request Parts만 없는 형식입니다.
+
+Request Parts:
+
+include::{snippets}/post/201/create/nofiles/request-parts.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/post/201/create/nofiles/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/post/201/create/nofiles/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/201/create/nofiles/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/201/create/nofiles/http-response.adoc[]
+
+==== Error
+
+Post 생성시 발생하는 오류는 다음과 같습니다.
+
+- 글의 내용이 없는 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/post/400/no-content/create/response-fields.adoc[]
+
+==== 글의 내용이 없는 경우
+
+CURL:
+
+include::{snippets}/post/400/no-content/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/400/no-content/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/400/no-content/create/http-response.adoc[]
+
+=== Read
+
+글 조회 API 관련 형식 및 예시
+
+Request Parameters:
+
+include::{snippets}/post/200/read/request-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/post/200/read/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/post/200/read/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/200/read/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/200/read/http-response.adoc[]
+
+=== Update
+
+글 수정 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/post/200/update/path-parameters.adoc[]
+
+Request 형식:
+
+include::{snippets}/post/200/update/request-fields.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/post/200/update/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/post/200/update/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/200/update/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/200/update/http-response.adoc[]
+
+==== Error
+
+글 수정시 발생하는 오류는 다음과 같습니다.
+
+- 현재 로그인 한 유저가 해당 글을 작성한 작성자가 아닌 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/post/400/no-auth/update/response-fields.adoc[]
+
+==== 현재 로그인 한 유저가 해당 글을 작성한 작성자가 아닌 경우
+
+CURL:
+
+include::{snippets}/post/400/no-auth/update/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/400/no-auth/update/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/400/no-auth/update/http-response.adoc[]
+
+=== Delete
+
+글 삭제 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/post/204/delete/path-parameters.adoc[]
+
+CURL:
+
+include::{snippets}/post/204/delete/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/204/delete/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/204/delete/http-response.adoc[]
+
+==== Error
+
+글 삭제시 발생하는 오류는 다음과 같습니다.
+
+- 현재 로그인 한 유저가 해당 글을 작성한 작성자가 아닌 경우
+- 존재하지 않는 글인 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/post/400/delete/no-auth/response-fields.adoc[]
+
+==== 현재 로그인 한 유저가 해당 글을 작성한 작성자가 아닌 경우
+
+CURL:
+
+include::{snippets}/post/400/delete/no-auth/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/400/delete/no-auth/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/400/delete/no-auth/http-response.adoc[]
+
+==== 존재하지 않는 글인 경우
+
+CURL:
+
+include::{snippets}/post/400/delete/none/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/400/delete/none/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/400/delete/none/http-response.adoc[]
+
+== Post Good
+
+게시글 좋아요 API 관련 형식 및 예시
+
+=== Toggle Good
+
+좋아요 및 좋아요 취소 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/post/200/good/create/path-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/post/200/good/create/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/post/200/good/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/200/good/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/200/good/create/http-response.adoc[]
+
+== Post Search
+
+게시글 검색 API 관련 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/post/200/search/path-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/post/200/search/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/post/200/search/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/post/200/search/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/post/200/search/http-response.adoc[]
+
+== Comment
+
+댓글 관련 API 형식 및 예시
+
+=== Create
+
+댓글 생성 관련 API 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/comment/201/create/path-parameters.adoc[]
+
+Request Body 형식:
+
+include::{snippets}/comment/201/create/request-fields.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/comment/201/create/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/comment/201/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/comment/201/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/comment/201/create/http-response.adoc[]
+
+=== READ
+
+댓글 조회 관련 API 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/comment/200/read/path-parameters.adoc[]
+
+Request Parameters:
+
+include::{snippets}/comment/200/read/request-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/comment/200/read/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/comment/200/read/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/comment/200/read/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/comment/200/read/http-response.adoc[]
+
+=== Update
+
+댓글 수정 관련 API 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/comment/200/update/path-parameters.adoc[]
+
+Request Body 형식:
+
+include::{snippets}/comment/200/update/request-fields.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/comment/200/update/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/comment/200/update/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/comment/200/update/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/comment/200/update/http-response.adoc[]
+
+==== Error
+
+댓글 수정시 발생할 수 있는 오류는 다음과 같습니다.
+
+- 현재 로그인 한 유저가 해당 댓글을 작성한 작성자가 아닌 경우
+
+이 모든 오류는 400 응답코드를 반환하며 다음과 같은 필드 형식을 같습니다.
+
+Response Body 형식:
+
+include::{snippets}/comment/400/update/no-auth/response-fields.adoc[]
+
+==== 현재 로그인 한 유저가 해당 댓글을 작성한 작성자가 아닌 경우
+
+CURL:
+
+include::{snippets}/comment/400/update/no-auth/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/comment/400/update/no-auth/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/comment/400/update/no-auth/http-response.adoc[]
+
+=== Delete
+
+댓글 삭제 관련 API 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/comment/204/delete/path-parameters.adoc[]
+
+CURL:
+
+include::{snippets}/comment/200/update/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/comment/200/update/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/comment/200/update/http-response.adoc[]
+
+== Comment Good
+
+댓글 & 답글 좋아요 관련 API 형식 및 예시
+
+=== Toggle Good
+
+좋아요 및 좋아요 취소 관련 API 형식 및 예시
+
+Request Path Parameters:
+
+include::{snippets}/comment/good/200/create/path-parameters.adoc[]
+
+Response Body 형식:
+
+include::{snippets}/comment/good/200/create/response-fields.adoc[]
+
+CURL:
+
+include::{snippets}/comment/good/200/create/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/comment/good/200/create/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/comment/good/200/create/http-response.adoc[]
+
+== Reply
+
+답글 관련 API 형식 및 예시
+
+답글은 댓글 작성과 거의 비슷한 형식을 띕니다. 답글 작성시 parentId를 전달하여 답글을 생성합니다.
+
+<<Comment>>
+
+=== Read
+
+CURL:
+
+include::{snippets}/comment/reply/200/read/curl-request.adoc[]
+
+요청 예시:
+
+include::{snippets}/comment/reply/200/read/http-request.adoc[]
+
+응답 예시:
+
+include::{snippets}/comment/reply/200/read/http-response.adoc[]

--- a/src/main/java/com/wootecobook/turkey/config/WebConfig.java
+++ b/src/main/java/com/wootecobook/turkey/config/WebConfig.java
@@ -26,6 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginInterceptor())
                 .addPathPatterns("/**")
                 .excludePathPatterns("/users/form", "/login", "/api/users")
+                .excludePathPatterns("/docs/api-guide.html")
                 .excludePathPatterns("/css/**", "/js/**", "/images/**");
     }
 

--- a/src/test/java/com/wootecobook/turkey/BaseControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/BaseControllerTests.java
@@ -5,13 +5,22 @@ import com.wootecobook.turkey.messenger.service.dto.MessengerRequest;
 import com.wootecobook.turkey.messenger.service.dto.MessengerRoomResponse;
 import com.wootecobook.turkey.user.service.dto.UserRequest;
 import com.wootecobook.turkey.user.service.dto.UserResponse;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
+
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 public abstract class BaseControllerTests {
     protected static final String JSESSIONID = "JSESSIONID";
     protected static final String VALID_USER_PASSWORD = "P@ssw0rd";
@@ -23,8 +32,33 @@ public abstract class BaseControllerTests {
     private static final String USER_API_URI = "/api/users";
     private static final String USER_API_URI_WITH_SLASH = USER_API_URI + "/";
 
-    @Autowired
     protected WebTestClient webTestClient;
+
+    protected final ResponseFieldsSnippet pageResponseSnippets = responseFields(
+            fieldWithPath("totalElements").description("총 Post 갯수"),
+            fieldWithPath("numberOfElements").description("현재 페이지에서 조회한 Post 갯수"),
+            fieldWithPath("totalPages").description("총 페이지 갯수"),
+            fieldWithPath("size").description("조회하려는 데이터의 갯수"),
+            fieldWithPath("number").description("현재 페이지 번호"),
+            fieldWithPath("first").description("첫번째 페이지 여부"),
+            fieldWithPath("last").description("마지막 페이지 여부"),
+            fieldWithPath("empty").description("현재 페이지 Post 정보 유무 여부")
+    );
+
+    protected final ResponseFieldsSnippet badRequestSnippets = responseFields(
+            fieldWithPath("message").description("에러 메세지")
+    );
+
+
+    @BeforeEach
+    void setUp(final RestDocumentationContextProvider restDocumentation) {
+        this.webTestClient = WebTestClient.bindToServer()
+                .filter(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+    }
 
     protected Long addUser(String name, String email, String password) {
         UserRequest userRequest = UserRequest.builder()

--- a/src/test/java/com/wootecobook/turkey/comment/controller/CommentApiControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/comment/controller/CommentApiControllerTests.java
@@ -292,7 +292,7 @@ class CommentApiControllerTests extends BaseControllerTests {
     }
 
     private Long addComment(CommentCreate commentCreate) {
-        final CommentResponse commentResponse = webTestClient.post().uri(uri)
+        final CommentResponse commentResponse = webTestClient.post().uri(COMMENT_API_URI, postId)
                 .accept(MEDIA_TYPE)
                 .cookie(JSESSIONID, jSessionId)
                 .body(Mono.just(commentCreate), CommentCreate.class)
@@ -301,6 +301,25 @@ class CommentApiControllerTests extends BaseControllerTests {
                 .expectHeader().contentType(MEDIA_TYPE)
                 .expectHeader().valueMatches("Location", ".*" + uri)
                 .expectBody(CommentResponse.class)
+                .consumeWith(document("comment/201/create",
+                        pathParameters(
+                                parameterWithName("postId").description("댓글을 작성하는 게시글의 고유 식별자")
+                        ),
+                        requestFields(
+                                fieldWithPath("contents").description("댓글 내용"),
+                                fieldWithPath("parentId").optional().type(JsonFieldType.NUMBER).description("답글인 경우 상위 댓글 고유 식별자")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("Comment 고유 식별자"),
+                                fieldWithPath("parentId").type(JsonFieldType.NUMBER).optional().description("해당 Comment의 상위 댓글 고유 식별자"),
+                                fieldWithPath("contents").description("Comment 내용"),
+                                fieldWithPath("countOfChildren").description("답글의 갯수"),
+                                fieldWithPath("createdAt").description("댓글 생성 날짜"),
+                                fieldWithPath("updatedAt").description("댓글 수정 날짜"),
+                                subsectionWithPath("userResponse").description("댓글 작성한 유저의 정보"),
+                                subsectionWithPath("goodResponse").description("댓글의 좋아요 정보")
+                        )
+                ))
                 .returnResult()
                 .getResponseBody();
 

--- a/src/test/java/com/wootecobook/turkey/comment/controller/CommentApiControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/comment/controller/CommentApiControllerTests.java
@@ -12,24 +12,27 @@ import com.wootecobook.turkey.post.service.dto.PostResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.client.MultipartBodyBuilder;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.restdocs.payload.JsonFieldType;
 import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @Import(AwsMockConfig.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class CommentApiControllerTests extends BaseControllerTests {
 
-    @Autowired
-    private WebTestClient webTestClient;
-
+    private static final String COMMENT_API_URI = "/api/posts/{postId}/comments";
     private Long userId;
+    private Long postId;
     private Long commentId;
     private String jSessionId;
     private String uri;
@@ -53,7 +56,7 @@ class CommentApiControllerTests extends BaseControllerTests {
                 .returnResult()
                 .getResponseBody();
 
-        final Long postId = postResponse.getId();
+        postId = postResponse.getId();
         uri = linkTo(CommentApiController.class, postId).toUri().toString();
 
         // 댓글 작성
@@ -73,13 +76,27 @@ class CommentApiControllerTests extends BaseControllerTests {
         final int page = 0;
 
         // when & then
-        webTestClient.get().uri(uri + "?size={size}&page={page}", size, page)
+        webTestClient.get().uri(COMMENT_API_URI + "?size={size}&page={page}", postId, size, page)
                 .accept(MEDIA_TYPE)
                 .cookie(JSESSIONID, jSessionId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MEDIA_TYPE)
                 .expectBody()
+                .consumeWith(document("comment/200/read",
+                        pathParameters(
+                                parameterWithName("postId").description("댓글을 작성할 Post 고유 식별자")
+                        ),
+                        requestParameters(
+                                parameterWithName("size").description("조회할 댓글의 갯수"),
+                                parameterWithName("page").description("조회할 페이지의 번호")
+                        ),
+                        pageResponseSnippets.and(
+                                subsectionWithPath("pageable").description("페이지 정보"),
+                                subsectionWithPath("content").description("조회하고자 하는 해당 페이지의 Post 목록"),
+                                subsectionWithPath("sort").description("조회 정렬 정보")
+                        )
+                ))
                 .jsonPath("$.size").isEqualTo(size)
                 .jsonPath("$.number").isEqualTo(page)
                 .jsonPath("$.totalElements").isEqualTo(1);
@@ -92,13 +109,28 @@ class CommentApiControllerTests extends BaseControllerTests {
         final int page = 0;
 
         // when & then
-        webTestClient.get().uri(uri + "/{id}/children?size={size}&page={page}", commentId, size, page)
+        webTestClient.get().uri(COMMENT_API_URI + "/{id}/children?size={size}&page={page}", postId, commentId, size, page)
                 .accept(MEDIA_TYPE)
                 .cookie(JSESSIONID, jSessionId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MEDIA_TYPE)
                 .expectBody()
+                .consumeWith(document("comment/reply/200/read",
+                        pathParameters(
+                                parameterWithName("postId").description("답글을 작성할 Post 고유 식별자"),
+                                parameterWithName("id").description("답글을 작성할 Comment 고유 식별자")
+                        ),
+                        requestParameters(
+                                parameterWithName("size").description("조회할 댓글의 갯수"),
+                                parameterWithName("page").description("조회할 페이지의 번호")
+                        ),
+                        pageResponseSnippets.and(
+                                subsectionWithPath("pageable").description("페이지 정보"),
+                                subsectionWithPath("content").description("조회하고자 하는 해당 페이지의 Post 목록"),
+                                subsectionWithPath("sort").description("조회 정렬 정보")
+                        )
+                ))
                 .jsonPath("$.size").isEqualTo(size)
                 .jsonPath("$.number").isEqualTo(page)
                 .jsonPath("$.totalElements").isEqualTo(2);
@@ -107,11 +139,21 @@ class CommentApiControllerTests extends BaseControllerTests {
     @Test
     void 댓글_삭제_성공() {
         // when & then
-        webTestClient.delete().uri(uri + "/{id}", commentId)
+        webTestClient.delete().uri(COMMENT_API_URI + "/{id}", postId, commentId)
                 .cookie(JSESSIONID, jSessionId)
                 .exchange()
                 .expectStatus().isNoContent()
-                .expectHeader().valueMatches("Location", ".*" + uri);
+                .expectHeader().valueMatches("Location", ".*" + uri)
+                .expectBody()
+                .consumeWith(document("comment/204/delete",
+                        pathParameters(
+                                parameterWithName("postId").description("Comment가 작성된 Post 고유 식별자"),
+                                parameterWithName("id").description("삭제하려는 Comment의 고유 식별자")
+                        ),
+                        responseHeaders(
+                                headerWithName("Location").description("삭제한 댓글의 Post 조회 URI")
+                        )
+                ));
     }
 
     @Test
@@ -121,13 +163,32 @@ class CommentApiControllerTests extends BaseControllerTests {
         commentUpdate.setContents("댓글_수정_성공");
 
         // when
-        final CommentResponse commentResponse = webTestClient.put().uri(uri + "/{id}", commentId)
+        final CommentResponse commentResponse = webTestClient.put().uri(COMMENT_API_URI + "/{id}", postId, commentId)
                 .cookie(JSESSIONID, jSessionId)
                 .body(Mono.just(commentUpdate), CommentUpdate.class)
                 .exchange()
                 .expectStatus().isOk()
                 .expectHeader().contentType(MEDIA_TYPE)
                 .expectBody(CommentResponse.class)
+                .consumeWith(document("comment/200/update",
+                        pathParameters(
+                                parameterWithName("postId").description("Comment가 작성된 Post 고유 식별자"),
+                                parameterWithName("id").description("삭제하려는 Comment의 고유 식별자")
+                        ),
+                        requestFields(
+                                fieldWithPath("contents").description("수정하려는 Comment의 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("Comment 고유 식별자"),
+                                fieldWithPath("parentId").type(JsonFieldType.NUMBER).optional().description("해당 Comment의 상위 댓글 고유 식별자"),
+                                fieldWithPath("contents").description("Comment 내용"),
+                                fieldWithPath("countOfChildren").description("답글의 갯수"),
+                                fieldWithPath("createdAt").description("댓글 생성 날짜"),
+                                fieldWithPath("updatedAt").description("댓글 수정 날짜"),
+                                subsectionWithPath("userResponse").description("댓글 작성한 유저의 정보"),
+                                subsectionWithPath("goodResponse").description("댓글의 좋아요 정보")
+                        )
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -147,12 +208,22 @@ class CommentApiControllerTests extends BaseControllerTests {
         commentUpdate.setContents("다른_작성자_댓글_수정_예외처리");
 
         // when
-        final ErrorMessage errorMessage = webTestClient.put().uri(uri + "/{id}", commentId)
+        final ErrorMessage errorMessage = webTestClient.put().uri(COMMENT_API_URI + "/{id}", postId, commentId)
                 .cookie(JSESSIONID, otherJsessionId)
                 .body(Mono.just(commentUpdate), CommentUpdate.class)
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody(ErrorMessage.class)
+                .consumeWith(document("comment/400/update/no-auth",
+                        pathParameters(
+                                parameterWithName("postId").description("Comment가 작성된 Post 고유 식별자"),
+                                parameterWithName("id").description("삭제하려는 Comment의 고유 식별자")
+                        ),
+                        requestFields(
+                                fieldWithPath("contents").description("수정하려는 Comment의 내용")
+                        ),
+                        badRequestSnippets
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -186,11 +257,21 @@ class CommentApiControllerTests extends BaseControllerTests {
     @Test
     void 댓글_좋아요_및_좋아요_취소_정상_로직() {
         // given & when
-        GoodResponse goodResponse = webTestClient.post().uri(uri + "/{id}/good", commentId)
+        GoodResponse goodResponse = webTestClient.post().uri(COMMENT_API_URI + "/{id}/good", postId, commentId)
                 .cookie(JSESSIONID, jSessionId)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(GoodResponse.class)
+                .consumeWith(document("comment/good/200/create",
+                        pathParameters(
+                                parameterWithName("postId").description("Comment가 작성된 Post 고유 식별자"),
+                                parameterWithName("id").description("삭제하려는 Comment의 고유 식별자")
+                        ),
+                        responseFields(
+                                fieldWithPath("totalGood").description("해당 게시글의 총 좋아요 갯수"),
+                                fieldWithPath("gooded").description("현재 로그인 한 유저의 해당 Post 좋아요 여부")
+                        )
+                ))
                 .returnResult()
                 .getResponseBody();
 

--- a/src/test/java/com/wootecobook/turkey/commons/aws/S3ConnectorTest.java
+++ b/src/test/java/com/wootecobook/turkey/commons/aws/S3ConnectorTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Import(AwsMockConfig.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class S3ConnectorTest {
 
     @Autowired

--- a/src/test/java/com/wootecobook/turkey/file/service/UploadFileServiceTest.java
+++ b/src/test/java/com/wootecobook/turkey/file/service/UploadFileServiceTest.java
@@ -15,7 +15,7 @@ import static com.wootecobook.turkey.config.AwsMockConfig.S3MOCK_ENDPOINT;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @Import(AwsMockConfig.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class UploadFileServiceTest {
 
     private static final String DIRECTORY_NAME = "testDir";

--- a/src/test/java/com/wootecobook/turkey/friend/controller/FriendApiControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/friend/controller/FriendApiControllerTests.java
@@ -133,7 +133,7 @@ class FriendApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody(ErrorMessage.class)
-                .consumeWith(document("friend/ask/400/create/already-friend",
+                .consumeWith(document("friend/ask/400/create/none",
                         friendAskRequestFieldsSnippet,
                         badRequestSnippets
                 ))
@@ -317,7 +317,7 @@ class FriendApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody(ErrorMessage.class)
-                .consumeWith(document("friend/ask/204/delete",
+                .consumeWith(document("friend/ask/400/delete",
                         pathParameters(
                                 parameterWithName("id").description("친구 요청 고유 식별자")
                         ),

--- a/src/test/java/com/wootecobook/turkey/login/controller/LoginApiControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/login/controller/LoginApiControllerTests.java
@@ -8,20 +8,17 @@ import com.wootecobook.turkey.user.service.UserService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
 import static com.wootecobook.turkey.login.service.exception.LoginFailException.LOGIN_FAIL_MESSAGE;
 import static com.wootecobook.turkey.user.domain.User.INVALID_PASSWORD_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class LoginApiControllerTests extends BaseControllerTests {
-
-    @Autowired
-    private WebTestClient webTestClient;
 
     private Long userId;
 
@@ -47,6 +44,19 @@ class LoginApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(UserSession.class)
+                .consumeWith(document("login",
+                        requestFields(
+                                fieldWithPath("email").description("로그인 시 필요한 이메일"),
+                                fieldWithPath("password").description("영문 대소문자, 특수문자, 숫자로 구성된 8자 이상 20자 이하의 비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("유저의 고유 id"),
+                                fieldWithPath("email").description("유저가 로그인 시 사용한 이메일"),
+                                fieldWithPath("name").description("유저의 name"),
+                                fieldWithPath("login").description("현재 로그인 유무"),
+                                subsectionWithPath("profile").description("유저의 등록 프로필")
+                        )
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -112,7 +122,9 @@ class LoginApiControllerTests extends BaseControllerTests {
                 .uri("/logout")
                 .cookie(JSESSIONID, logIn(VALID_USER_EMAIL, VALID_USER_PASSWORD))
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isOk()
+                .expectBody()
+                .consumeWith(document("logout"));
     }
 
     @Test

--- a/src/test/java/com/wootecobook/turkey/post/controller/PostApiControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/post/controller/PostApiControllerTests.java
@@ -10,31 +10,44 @@ import com.wootecobook.turkey.post.service.dto.PostResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
-import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 @Import(AwsMockConfig.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class PostApiControllerTests extends BaseControllerTests {
 
     public static final String POST_URL = "/api/posts";
 
-    @Autowired
-    private WebTestClient webTestClient;
-
     private Long authorId;
     private String authorJSessionId;
+
     private Long otherId;
     private String otherJSessionId;
+
     private ByteArrayResource testFile;
+
+    private final ResponseFieldsSnippet postResponseSnippets = responseFields(
+            fieldWithPath("id").description("글의 고유 id"),
+            fieldWithPath("contents.contents").description("글의 내용"),
+            fieldWithPath("createdAt").description("글 작성 일자"),
+            fieldWithPath("updatedAt").description("글 수정 일자"),
+            fieldWithPath("totalComment").description("글에 달린 댓글의 총 갯수"),
+            subsectionWithPath("files").description("글과 함께 업로드 된 사진 또는 동영상 정보"),
+            subsectionWithPath("author").description("작성자 정보"),
+            subsectionWithPath("receiver").optional().description("글 받는 사람 정보"),
+            subsectionWithPath("goodResponse").description("해당 글의 좋아요 정보")
+    );
 
     @BeforeEach
     void setUp() {
@@ -65,6 +78,14 @@ class PostApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isCreated()
                 .expectBody(PostResponse.class)
+                .consumeWith(document("post/201/create/withfiles",
+                        requestParts(
+                                partWithName("contents").description("글의 내용"),
+                                partWithName("files").optional().description("글과 함께 업로드하는 사진 또는 동영상, 여러장 가능"),
+                                partWithName("receiver").optional().description("다른 유저에게 글쓰는 경우, 해당 유저의 id")
+                        ),
+                        postResponseSnippets
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -86,6 +107,14 @@ class PostApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isCreated()
                 .expectBody(PostResponse.class)
+                .consumeWith(document("post/201/create/nofiles",
+                        requestParts(
+                                partWithName("contents").description("글의 내용"),
+                                partWithName("files").optional().description("글과 함께 업로드하는 사진 또는 동영상, 여러장 가능"),
+                                partWithName("receiver").optional().description("다른 유저에게 글쓰는 경우, 해당 유저의 id")
+                        ),
+                        postResponseSnippets
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -107,6 +136,9 @@ class PostApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectBody(ErrorMessage.class)
+                .consumeWith(document("post/400/no-content/create",
+                        badRequestSnippets
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -117,10 +149,22 @@ class PostApiControllerTests extends BaseControllerTests {
     @Test
     void 페이지_조회_정상_로직_테스트() {
         //when & then
-        webTestClient.get().uri(POST_URL)
+        webTestClient.get().uri(POST_URL + "?page=0")
                 .cookie(JSESSIONID, authorJSessionId)
                 .exchange()
-                .expectStatus().isOk();
+                .expectStatus().isOk()
+                .expectBody()
+                .consumeWith(System.out::println)
+                .consumeWith(document("post/200/read",
+                        relaxedRequestParameters(
+                                parameterWithName("page").description("페이지 번호")
+                        ),
+                        pageResponseSnippets.and(
+                                subsectionWithPath("pageable").description("페이지 정보"),
+                                subsectionWithPath("content").description("조회하고자 하는 해당 페이지의 Post 목록"),
+                                subsectionWithPath("sort").description("조회 정렬 정보")
+                        )
+                ));
     }
 
     @Test
@@ -138,6 +182,15 @@ class PostApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(PostResponse.class)
+                .consumeWith(document("post/200/update",
+                        pathParameters(
+                                parameterWithName("postId").description("수정할 Post의 id")
+                        ),
+                        relaxedRequestFields(
+                                fieldWithPath("contents").description("수정할 글의 내용")
+                        ),
+                        postResponseSnippets
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -174,7 +227,11 @@ class PostApiControllerTests extends BaseControllerTests {
                 .contentType(MEDIA_TYPE)
                 .body(Mono.just(postUpdateRequest), PostRequest.class)
                 .exchange()
-                .expectStatus().isBadRequest();
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .consumeWith(document("post/400/no-auth/update",
+                        badRequestSnippets
+                ));;
     }
 
     @Test
@@ -186,7 +243,13 @@ class PostApiControllerTests extends BaseControllerTests {
         webTestClient.delete().uri(POST_URL + "/{postId}", postId)
                 .cookie(JSESSIONID, authorJSessionId)
                 .exchange()
-                .expectStatus().isNoContent();
+                .expectStatus().isNoContent()
+                .expectBody()
+                .consumeWith(document("post/204/delete",
+                        pathParameters(
+                                parameterWithName("postId").description("해당 Post의 고유 식별 id")
+                        )
+                ));
     }
 
     @Test
@@ -195,7 +258,14 @@ class PostApiControllerTests extends BaseControllerTests {
         webTestClient.delete().uri(POST_URL + "/{postId}", Long.MAX_VALUE)
                 .cookie(JSESSIONID, authorJSessionId)
                 .exchange()
-                .expectStatus().isBadRequest();
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .consumeWith(document("post/400/delete/none",
+                        pathParameters(
+                                parameterWithName("postId").description("해당 Post의 고유 식별 id")
+                        ),
+                        badRequestSnippets
+                ));
     }
 
     @Test
@@ -207,7 +277,14 @@ class PostApiControllerTests extends BaseControllerTests {
         webTestClient.delete().uri(POST_URL + "/{postId}", postId)
                 .cookie(JSESSIONID, otherJSessionId)
                 .exchange()
-                .expectStatus().isBadRequest();
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .consumeWith(document("post/400/delete/no-auth",
+                        pathParameters(
+                                parameterWithName("postId").description("해당 Post의 고유 식별 id")
+                        ),
+                        badRequestSnippets
+                ));
     }
 
     @Test
@@ -221,6 +298,15 @@ class PostApiControllerTests extends BaseControllerTests {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(GoodResponse.class)
+                .consumeWith(document("post/200/good/create",
+                        pathParameters(
+                                parameterWithName("postId").description("해당 Post의 고유 식별 id")
+                        ),
+                        responseFields(
+                                fieldWithPath("totalGood").description("해당 게시글의 총 좋아요 갯수"),
+                                fieldWithPath("gooded").description("현재 로그인 한 유저의 해당 Post 좋아요 여부")
+                        )
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -239,7 +325,6 @@ class PostApiControllerTests extends BaseControllerTests {
         // then
         assertThat(postGoodCancelResponse.getTotalGood()).isEqualTo(0);
     }
-
 
     private Long addPost(String contents) {
         //given

--- a/src/test/java/com/wootecobook/turkey/search/controller/SearchControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/search/controller/SearchControllerTests.java
@@ -8,7 +8,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class SearchControllerTests extends BaseControllerTests {
 
     private final String uri = linkTo(SearchController.class).toString();

--- a/src/test/java/com/wootecobook/turkey/user/controller/IntroductionApiControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/user/controller/IntroductionApiControllerTests.java
@@ -9,14 +9,23 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.PathParametersSnippet;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
-import static com.wootecobook.turkey.user.service.IntroductionService.*;
+import static com.wootecobook.turkey.user.service.IntroductionService.MISMATCH_USER_MESSAGE;
+import static com.wootecobook.turkey.user.service.IntroductionService.NOT_FOUND_INTRODUCTION_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document;
 
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class IntroductionApiControllerTests extends BaseControllerTests {
 
     private static final String INTRODUCTION_URI = "/api/users/{userId}/introduction";
@@ -24,6 +33,19 @@ class IntroductionApiControllerTests extends BaseControllerTests {
     private static final String CURRENT_CITY = "CURRENT_CITY";
     private static final String EDUCATION = "EDUCATION";
     private static final String COMPANY = "COMPANY";
+
+    private final PathParametersSnippet userIdPathParametersSnippet = pathParameters(
+            parameterWithName("userId").description("해당 소개 정보를 가지는 유저의 id")
+    );
+
+    private final ResponseFieldsSnippet introductionResponseFieldsSnippet = responseFields(
+            fieldWithPath("id").description("소개의 고유 식별자"),
+            fieldWithPath("currentCity").type(JsonFieldType.STRING).optional().description("유저의 거주 도시"),
+            fieldWithPath("hometown").type(JsonFieldType.STRING).optional().description("유저의 출신지"),
+            fieldWithPath("company").type(JsonFieldType.STRING).optional().description("유저의 현재 회사"),
+            fieldWithPath("education").type(JsonFieldType.STRING).optional().description("유저의 학력"),
+            fieldWithPath("userId").description("해당 유저의 고유 식별자")
+    );
 
     @Autowired
     private WebTestClient webTestClient;
@@ -43,6 +65,10 @@ class IntroductionApiControllerTests extends BaseControllerTests {
                 .cookie(JSESSIONID, logIn(VALID_USER_EMAIL, VALID_USER_PASSWORD))
                 .exchange()
                 .expectBody(IntroductionResponse.class)
+                .consumeWith(document("introduction/200/create",
+                        userIdPathParametersSnippet,
+                        introductionResponseFieldsSnippet
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -62,6 +88,10 @@ class IntroductionApiControllerTests extends BaseControllerTests {
                 .cookie(JSESSIONID, logIn(VALID_USER_EMAIL, VALID_USER_PASSWORD))
                 .exchange()
                 .expectBody(ErrorMessage.class)
+                .consumeWith(document("introduction/400/create",
+                        userIdPathParametersSnippet,
+                        badRequestSnippets
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -87,6 +117,10 @@ class IntroductionApiControllerTests extends BaseControllerTests {
                 .body(Mono.just(introductionRequest), IntroductionRequest.class)
                 .exchange()
                 .expectBody(IntroductionResponse.class)
+                .consumeWith(document("introduction/200/update",
+                        userIdPathParametersSnippet,
+                        introductionResponseFieldsSnippet
+                ))
                 .returnResult()
                 .getResponseBody();
 
@@ -117,6 +151,10 @@ class IntroductionApiControllerTests extends BaseControllerTests {
                 .body(Mono.just(introductionRequest), IntroductionRequest.class)
                 .exchange()
                 .expectBody(ErrorMessage.class)
+                .consumeWith(document("introduction/400/update",
+                        userIdPathParametersSnippet,
+                        badRequestSnippets
+                ))
                 .returnResult()
                 .getResponseBody();
 

--- a/src/test/java/com/wootecobook/turkey/user/controller/UserControllerTests.java
+++ b/src/test/java/com/wootecobook/turkey/user/controller/UserControllerTests.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 class UserControllerTests {
 
     @Autowired


### PR DESCRIPTION
Spring REST Docs 프로젝트를 활용해서 현재 존재하는 테스트를 기반으로 API 문서화를 했습니다.
단순 노가다 작업이 많았어서 누락된 부분이 있을수도 있습니다. 확인부탁드려요 ㅎㅎ

build 후에 `java -jar -Dspirng.profile.active=dev {생성된 jar}` 명령으로 실행하고 `http://localhost:8080/docs/api-guide.html`로 접근하면 API 문서를 확인하실 수 있습니다.

- BaseControllerTests RestDocumentation 설정
- api-guide.adoc으로 전체 API 문서
- Interceptor에서 API 문서 경로 제거

resolved #94 